### PR TITLE
Support SixLabors.ImageSharp V3+ on .NET8

### DIFF
--- a/src/StreamDeckSharp/StreamDeckSharp.csproj
+++ b/src/StreamDeckSharp/StreamDeckSharp.csproj
@@ -19,9 +19,15 @@
 
   <ItemGroup>
     <PackageReference Include="HidSharp" Version="2.6.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
     <ProjectReference Include="..\..\..\OpenMacroBoard.SDK\src\OpenMacroBoard.SDK\OpenMacroBoard.SDK.csproj" />
     <None Include="icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added conditional include to support both v2 and v3 depending on the target framework